### PR TITLE
Update fields returned and city name

### DIFF
--- a/spec/filters/geoip_spec.rb
+++ b/spec/filters/geoip_spec.rb
@@ -93,7 +93,7 @@ describe LogStash::Filters::GeoIP do
 
       it "should set other subfields of 'target' properly" do
         expect(event.get("target").to_hash.keys.sort).to eq(["city_name", "ip", "region_name"])
-        expect(event.get("[target][city_name]")).to eq("Watertown")
+        expect(event.get("[target][city_name]")).to eq("Salem")
         expect(event.get("[target][region_name]")).to eq("Massachusetts")
       end
 
@@ -248,7 +248,7 @@ describe LogStash::Filters::GeoIP do
           expect(event.get("geoip")).not_to be_empty
           expect(event.get("geoip")["ip"]).to eq("2607:f0d0:1002:51:0:0:0:4")
           expect(event.get("geoip").to_hash.keys.sort).to eq(
-            ["continent_code", "country_code2", "country_code3", "country_name", "ip", "latitude", "location", "longitude"]
+            ["city_name", "continent_code", "country_code2", "country_code3", "country_name", "dma_code", "ip", "latitude", "location", "longitude", "postal_code", "region_code", "region_name", "timezone"]
           )
         end
       end


### PR DESCRIPTION
MaxMind adjusted some of their data, so now the test IP that resolved to Watertown, MA, US, now resolves to Salem, MA, US.

Additionally, the list of fields returned has changed in another test case, so list all the fields that are now returned.
